### PR TITLE
feat: support Japan data in Yahoo collector

### DIFF
--- a/qlib/constant.py
+++ b/qlib/constant.py
@@ -10,6 +10,7 @@ import pandas as pd
 REG_CN = "cn"
 REG_US = "us"
 REG_TW = "tw"
+REG_JP = "jp"
 
 # Epsilon for avoiding division by zero.
 EPS = 1e-12

--- a/scripts/data_collector/utils.py
+++ b/scripts/data_collector/utils.py
@@ -37,6 +37,8 @@ CALENDAR_BENCH_URL_MAP = {
     "US_ALL": "^GSPC",
     "IN_ALL": "^NSEI",
     "BR_ALL": "^BVSP",
+    # NOTE: Use the time series of ^N225(Nikkei 225) as the sequence of all stocks
+    "JP_ALL": "^N225",
 }
 
 _BENCH_CALENDAR_LIST = None
@@ -45,6 +47,7 @@ _HS_SYMBOLS = None
 _US_SYMBOLS = None
 _IN_SYMBOLS = None
 _BR_SYMBOLS = None
+_JP_SYMBOLS = None
 _EN_FUND_SYMBOLS = None
 _CALENDAR_MAP = {}
 
@@ -58,7 +61,7 @@ def get_calendar_list(bench_code="CSI300") -> List[pd.Timestamp]:
     Parameters
     ----------
     bench_code: str
-        value from ["CSI300", "CSI500", "ALL", "US_ALL"]
+        value from ["CSI300", "CSI500", "ALL", "US_ALL", "IN_ALL", "BR_ALL", "JP_ALL"]
 
     Returns
     -------
@@ -73,7 +76,7 @@ def get_calendar_list(bench_code="CSI300") -> List[pd.Timestamp]:
 
     calendar = _CALENDAR_MAP.get(bench_code, None)
     if calendar is None:
-        if bench_code.startswith("US_") or bench_code.startswith("IN_") or bench_code.startswith("BR_"):
+        if bench_code.startswith("US_") or bench_code.startswith("IN_") or bench_code.startswith("BR_") or bench_code.startswith("JP_"):
             print(Ticker(CALENDAR_BENCH_URL_MAP[bench_code]))
             print(Ticker(CALENDAR_BENCH_URL_MAP[bench_code]).history(interval="1d", period="max"))
             df = Ticker(CALENDAR_BENCH_URL_MAP[bench_code]).history(interval="1d", period="max")
@@ -467,6 +470,30 @@ def get_br_stock_symbols(qlib_data_path: [str, Path] = None) -> list:
         _BR_SYMBOLS = sorted(set(map(_format, _all_symbols)))
 
     return _BR_SYMBOLS
+
+
+def get_jp_stock_symbols(qlib_data_path: [str, Path] = None) -> list:
+    """get Japan (TSE Prime) stock symbols"""
+
+    global _JP_SYMBOLS  # pylint: disable=W0603
+
+    @deco_retry
+    def _get_jpx():
+        url = "https://raw.githubusercontent.com/FinanceData/FinanceData/master/finance_data/JPX/jpx_prime_list.csv"
+        df = pd.read_csv(url)
+        if "Code" in df.columns:
+            codes = df["Code"].astype(str)
+        elif "コード" in df.columns:
+            codes = df["コード"].astype(str)
+        else:
+            codes = df.iloc[:, 0].astype(str)
+        codes = codes.str.zfill(4) + ".T"
+        return codes.unique().tolist()
+
+    if _JP_SYMBOLS is None:
+        _JP_SYMBOLS = sorted(set(_get_jpx()))
+
+    return _JP_SYMBOLS
 
 
 def get_en_fund_symbols(qlib_data_path: [str, Path] = None) -> list:

--- a/scripts/data_collector/yahoo/collector.py
+++ b/scripts/data_collector/yahoo/collector.py
@@ -38,6 +38,7 @@ from data_collector.utils import (
     get_us_stock_symbols,
     get_in_stock_symbols,
     get_br_stock_symbols,
+    get_jp_stock_symbols,
     generate_minutes_calendar_from_daily,
     calc_adjusted_price,
 )
@@ -364,6 +365,32 @@ class YahooCollectorBR1min(YahooCollectorBR):
     retry = 2
 
 
+class YahooCollectorJP(YahooCollector, ABC):
+    def get_instrument_list(self):
+        logger.info("get JP stock symbols......")
+        symbols = get_jp_stock_symbols()
+        logger.info(f"get {len(symbols)} symbols.")
+        return symbols
+
+    def download_index_data(self):
+        pass
+
+    def normalize_symbol(self, symbol):
+        return code_to_fname(symbol).upper()
+
+    @property
+    def _timezone(self):
+        return "Asia/Tokyo"
+
+
+class YahooCollectorJP1d(YahooCollectorJP):
+    pass
+
+
+class YahooCollectorJP1min(YahooCollectorJP):
+    pass
+
+
 class YahooNormalize(BaseNormalize):
     COLUMNS = ["open", "close", "high", "low", "volume"]
     DAILY_FORMAT = "%Y-%m-%d"
@@ -669,6 +696,29 @@ class YahooNormalizeIN1min(YahooNormalizeIN, YahooNormalize1min):
         return fname_to_code(symbol)
 
 
+class YahooNormalizeJP:
+    def _get_calendar_list(self) -> Iterable[pd.Timestamp]:
+        return get_calendar_list("JP_ALL")
+
+
+class YahooNormalizeJP1d(YahooNormalizeJP, YahooNormalize1d):
+    pass
+
+
+class YahooNormalizeJP1min(YahooNormalizeJP, YahooNormalize1min):
+    CALC_PAUSED_NUM = False
+
+    def _get_calendar_list(self) -> Iterable[pd.Timestamp]:
+        # TODO: support 1min
+        raise ValueError("Does not support 1min")
+
+    def _get_1d_calendar_list(self):
+        return get_calendar_list("JP_ALL")
+
+    def symbol_to_yahoo(self, symbol):
+        return fname_to_code(symbol)
+
+
 class YahooNormalizeCN:
     def _get_calendar_list(self) -> Iterable[pd.Timestamp]:
         # TODO: from MSN
@@ -739,7 +789,7 @@ class Run(BaseRun):
         interval: str
             freq, value from [1min, 1d], default 1d
         region: str
-            region, value from ["CN", "US", "BR"], default "CN"
+            region, value from ["CN", "US", "IN", "BR", "JP"], default "CN"
         """
         super().__init__(source_dir, normalize_dir, max_workers, interval)
         self.region = region


### PR DESCRIPTION
## Summary
- add `REG_JP` constant and calendar mapping for Japan
- fetch JPX Prime stock symbols and support JP region in Yahoo collector
- provide normalization classes for Japanese data

## Testing
- `python -m py_compile scripts/data_collector/utils.py scripts/data_collector/yahoo/collector.py qlib/constant.py`
- `pre-commit run --files scripts/data_collector/utils.py scripts/data_collector/yahoo/collector.py qlib/constant.py` *(failed: command not found; `pip install pre-commit` failed: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c4cbab44e0832282be4dcb7b78de24