### PR TITLE
Add LightGBM workflow config for Japan region

### DIFF
--- a/examples/benchmarks/LightGBM/workflow_config_lightgbm_Alpha158_jp.yaml
+++ b/examples/benchmarks/LightGBM/workflow_config_lightgbm_Alpha158_jp.yaml
@@ -1,0 +1,71 @@
+qlib_init:
+    provider_uri: "~/.qlib/qlib_data/jp_data"
+    region: jp
+market: &market jp_all
+benchmark: &benchmark "^N225"
+data_handler_config: &data_handler_config
+    start_time: 2008-01-01
+    end_time: 2020-08-01
+    fit_start_time: 2008-01-01
+    fit_end_time: 2014-12-31
+    instruments: *market
+port_analysis_config: &port_analysis_config
+    strategy:
+        class: TopkDropoutStrategy
+        module_path: qlib.contrib.strategy
+        kwargs:
+            signal: <PRED>
+            topk: 50
+            n_drop: 5
+    backtest:
+        start_time: 2017-01-01
+        end_time: 2020-08-01
+        account: 100000000
+        benchmark: *benchmark
+        exchange_kwargs:
+            limit_threshold: 0.095
+            deal_price: close
+            open_cost: 0.0005
+            close_cost: 0.0015
+            min_cost: 5
+task:
+    model:
+        class: LGBModel
+        module_path: qlib.contrib.model.gbdt
+        kwargs:
+            loss: mse
+            colsample_bytree: 0.8879
+            learning_rate: 0.2
+            subsample: 0.8789
+            lambda_l1: 205.6999
+            lambda_l2: 580.9768
+            max_depth: 8
+            num_leaves: 210
+            num_threads: 20
+    dataset:
+        class: DatasetH
+        module_path: qlib.data.dataset
+        kwargs:
+            handler:
+                class: Alpha158
+                module_path: qlib.contrib.data.handler
+                kwargs: *data_handler_config
+            segments:
+                train: [2008-01-01, 2014-12-31]
+                valid: [2015-01-01, 2016-12-31]
+                test: [2017-01-01, 2020-08-01]
+    record: 
+        - class: SignalRecord
+          module_path: qlib.workflow.record_temp
+          kwargs: 
+            model: <MODEL>
+            dataset: <DATASET>
+        - class: SigAnaRecord
+          module_path: qlib.workflow.record_temp
+          kwargs: 
+            ana_long_short: False
+            ann_scaler: 252
+        - class: PortAnaRecord
+          module_path: qlib.workflow.record_temp
+          kwargs: 
+            config: *port_analysis_config


### PR DESCRIPTION
## Summary
- add LightGBM Alpha158 workflow configuration for JP region

## Testing
- `pre-commit run --files examples/benchmarks/LightGBM/workflow_config_lightgbm_Alpha158_jp.yaml`
- `pytest tests/test_register_ops.py -k test_regiter_custom_ops -q`

------
https://chatgpt.com/codex/tasks/task_e_68c53337e80483229dd046351f03bdfe