### PR TITLE
Add LightGBM workflow config for Japan region

### DIFF
--- a/examples/benchmarks/LightGBM/workflow_config_lightgbm_Alpha158_jp.yaml
+++ b/examples/benchmarks/LightGBM/workflow_config_lightgbm_Alpha158_jp.yaml
@@ -1,0 +1,71 @@
+qlib_init:
+    provider_uri: "~/.qlib/qlib_data/jp_data"
+    region: jp
+market: &market jp_all
+benchmark: &benchmark "^N225"
+data_handler_config: &data_handler_config
+    start_time: 2008-01-01
+    end_time: 2020-08-01
+    fit_start_time: 2008-01-01
+    fit_end_time: 2014-12-31
+    instruments: *market
+port_analysis_config: &port_analysis_config
+    strategy:
+        class: TopkDropoutStrategy
+        module_path: qlib.contrib.strategy
+        kwargs:
+            signal: <PRED>
+            topk: 50
+            n_drop: 5
+    backtest:
+        start_time: 2017-01-01
+        end_time: 2020-08-01
+        account: 100000000
+        benchmark: *benchmark
+        exchange_kwargs:
+            limit_threshold: 0.095
+            deal_price: close
+            open_cost: 0.0005
+            close_cost: 0.0015
+            min_cost: 5
+task:
+    model:
+        class: LGBModel
+        module_path: qlib.contrib.model.gbdt
+        kwargs:
+            loss: mse
+            colsample_bytree: 0.8879
+            learning_rate: 0.2
+            subsample: 0.8789
+            lambda_l1: 205.6999
+            lambda_l2: 580.9768
+            max_depth: 8
+            num_leaves: 210
+            num_threads: 20
+    dataset:
+        class: DatasetH
+        module_path: qlib.data.dataset
+        kwargs:
+            handler:
+                class: Alpha158
+                module_path: qlib.contrib.data.handler
+                kwargs: *data_handler_config
+            segments:
+                train: [2008-01-01, 2014-12-31]
+                valid: [2015-01-01, 2016-12-31]
+                test: [2017-01-01, 2020-08-01]
+    record: 
+        - class: SignalRecord
+          module_path: qlib.workflow.record_temp
+          kwargs: 
+            model: <MODEL>
+            dataset: <DATASET>
+        - class: SigAnaRecord
+          module_path: qlib.workflow.record_temp
+          kwargs: 
+            ana_long_short: False
+            ann_scaler: 252
+        - class: PortAnaRecord
+          module_path: qlib.workflow.record_temp
+          kwargs: 
+            config: *port_analysis_config

--- a/qlib/config.py
+++ b/qlib/config.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import Callable, Optional, Union
 from typing import TYPE_CHECKING
 
-from qlib.constant import REG_CN, REG_US, REG_TW
+from qlib.constant import REG_CN, REG_US, REG_TW, REG_JP
 
 if TYPE_CHECKING:
     from qlib.utils.time import Freq
@@ -306,6 +306,11 @@ _default_region_config = {
     REG_TW: {
         "trade_unit": 1000,
         "limit_threshold": 0.1,
+        "deal_price": "close",
+    },
+    REG_JP: {
+        "trade_unit": 100,
+        "limit_threshold": None,
         "deal_price": "close",
     },
 }

--- a/qlib/constant.py
+++ b/qlib/constant.py
@@ -10,6 +10,7 @@ import pandas as pd
 REG_CN = "cn"
 REG_US = "us"
 REG_TW = "tw"
+REG_JP = "jp"
 
 # Epsilon for avoiding division by zero.
 EPS = 1e-12

--- a/qlib/utils/time.py
+++ b/qlib/utils/time.py
@@ -12,7 +12,7 @@ import re
 import pandas as pd
 
 from qlib.config import C
-from qlib.constant import REG_CN, REG_TW, REG_US
+from qlib.constant import REG_CN, REG_TW, REG_US, REG_JP
 
 
 CN_TIME = [
@@ -25,6 +25,12 @@ US_TIME = [datetime.strptime("9:30", "%H:%M"), datetime.strptime("16:00", "%H:%M
 TW_TIME = [
     datetime.strptime("9:00", "%H:%M"),
     datetime.strptime("13:30", "%H:%M"),
+]
+JP_TIME = [
+    datetime.strptime("9:00", "%H:%M"),
+    datetime.strptime("11:30", "%H:%M"),
+    datetime.strptime("12:30", "%H:%M"),
+    datetime.strptime("15:00", "%H:%M"),
 ]
 
 
@@ -63,6 +69,13 @@ def get_min_cal(shift: int = 0, region: str = REG_CN) -> List[time]:
     elif region == REG_US:
         for ts in list(
             pd.date_range(US_TIME[0], US_TIME[1] - timedelta(minutes=1), freq="1min") - pd.Timedelta(minutes=shift)
+        ):
+            cal.append(ts.time())
+    elif region == REG_JP:
+        for ts in list(
+            pd.date_range(JP_TIME[0], JP_TIME[1] - timedelta(minutes=1), freq="1min") - pd.Timedelta(minutes=shift)
+        ) + list(
+            pd.date_range(JP_TIME[2], JP_TIME[3] - timedelta(minutes=1), freq="1min") - pd.Timedelta(minutes=shift)
         ):
             cal.append(ts.time())
     else:
@@ -105,6 +118,14 @@ def is_single_value(start_time, end_time, freq, region: str = REG_CN):
         if end_time - start_time < freq:
             return True
         if start_time.hour == 15 and start_time.minute == 59 and start_time.second == 0:
+            return True
+        return False
+    elif region == REG_JP:
+        if end_time - start_time < freq:
+            return True
+        if start_time.hour == 11 and start_time.minute == 29 and start_time.second == 0:
+            return True
+        if start_time.hour == 14 and start_time.minute == 59 and start_time.second == 0:
             return True
         return False
     else:
@@ -264,6 +285,13 @@ def time_to_day_index(time_obj: Union[str, datetime], region: str = REG_CN):
             return int((time_obj - CN_TIME[0]).total_seconds() / 60)
         elif CN_TIME[2] <= time_obj < CN_TIME[3]:
             return int((time_obj - CN_TIME[2]).total_seconds() / 60) + 120
+        else:
+            raise ValueError(f"{time_obj} is not the opening time of the {region} stock market")
+    elif region == REG_JP:
+        if JP_TIME[0] <= time_obj < JP_TIME[1]:
+            return int((time_obj - JP_TIME[0]).total_seconds() / 60)
+        elif JP_TIME[2] <= time_obj < JP_TIME[3]:
+            return int((time_obj - JP_TIME[2]).total_seconds() / 60) + 150
         else:
             raise ValueError(f"{time_obj} is not the opening time of the {region} stock market")
     elif region == REG_US:


### PR DESCRIPTION
## Summary
- add LightGBM Alpha158 workflow configuration for JP region
- define JP region constants and trading calendar support

## Testing
- `pre-commit run --files qlib/constant.py qlib/config.py qlib/utils/time.py examples/benchmarks/LightGBM/workflow_config_lightgbm_Alpha158_jp.yaml` *(fails: AttributeError: 'EntryPoints' object has no attribute 'get')*
- `PYTHONPATH=. pytest tests/test_register_ops.py -k test_regiter_custom_ops -q`
- `PYTHONPATH=. pytest tests/misc/test_utils.py::TimeUtils::test_cal_sam_minute -q`
- `qrun examples/benchmarks/LightGBM/workflow_config_lightgbm_Alpha158_jp.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68c53337e80483229dd046351f03bdfe